### PR TITLE
Fix cut problem

### DIFF
--- a/battery
+++ b/battery
@@ -60,10 +60,10 @@ elif [ $BATTERY_STATUS -lt 25 ]; then
 
 fi
 
-GRAPH=$(spark 0 ${BATTERY_STATUS} 100 | cut -c2)
+GRAPH=$(spark 0 ${BATTERY_STATUS} 100 | awk '{print substr($0,4,3)}')
 
 if [ "$tmux" == "false" ]; then
-    printf "\e[0;%sm %s %s \e[m\n"  "$COLOR" "[$BATTERY_STATUS%]"  "$GRAPH"
+    printf "\e[0;%sm%s %s \e[m\n"  "$COLOR" "[$BATTERY_STATUS%]"  "$GRAPH"
 else
-    printf "%s %s %s" "$COLOR" "[$BATTERY_STATUS%]" "$GRAPH"
+    printf "%s%s %s" "$COLOR" "[$BATTERY_STATUS%]" "$GRAPH"
 fi


### PR DESCRIPTION
I don't know how you got `spark | cut -c2` to work properly… There's a bug in cut when working with unicode. It always returns `?` instead of the spark.
