### PR TITLE
More concise ioreg arguments

### DIFF
--- a/battery
+++ b/battery
@@ -2,7 +2,7 @@
 
 battery_charge()
 {
-    ioreg -c AppleSmartBattery -w0 | \
+    ioreg -n AppleSmartBattery -r | \
     grep -o '"[^"]*" = [^ ]*' | \
     sed -e 's/= //g' -e 's/"//g' | \
     sort | \


### PR DESCRIPTION
Just check the `ioreg -n AppleSmartBattery -r` output.
