### PR TITLE
Linux support merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ Battery is a little bash script that uses [Spark](https://github.com/holman/spar
 
 ### Requirements
 
-Right now, battery requires [Spark](https://github.com/holman/spark) to graph your battery status, and only runs on __Mac OS X__.
+Right now, battery requires [Spark](https://github.com/holman/spark) to graph your battery status.
+Battery can run on both __Mac OS X__ and Linux.
 
 If you don't want to use Spark, you can use the `-a` flag, for ascii output:
 ![image](http://i.imgur.com/w9qtQeu.png)
 
-# Install
+# Install - Mac
 
 ### Homebrew
 
@@ -33,6 +34,7 @@ Just do (case sensitive)
 	brew install spark; curl -O https://raw.github.com/Goles/Battery/master/battery ; \
 	sudo mv battery /usr/bin; sudo chmod 755 /usr/bin/battery
 
+
 ### Step by Step
 
 * Install spark (with [Homebrew](https://github.com/mxcl/homebrew) on Mac OS X)
@@ -44,6 +46,34 @@ Just do (case sensitive)
 	``` sudo cp battery /usr/bin ```
 
 	``` sudo chmod 755 /usr/bin/battery ```
+
+# Install - Linux
+
+Linux support is still being tested. It ought to work properly in Debian and
+Ubuntu, but is largely untested in other distributions. Using linux requires
+`upower`, which should be included, or available, on most linux distributions.
+
+It's recommended to install this somewhere in your path that is writable,
+like `/usr/local/bin`
+
+```bash
+# if you also want to use spark
+curl -O https://raw.githubusercontent.com/holman/spark/master/spark
+mv spark /usr/local/bin
+chmod u+x /usr/local/bin/spark
+
+curl -O https://raw.githubusercontent.com/goles/battery/master/battery
+mv spark battery /usr/local/bin
+chmod u+x /usr/local/bin/battery
+```
+__NOTE:__ This `spark` is *not* the same `spark` that you would install by doing
+
+```bash
+$ sudo aptitude install spark
+```
+That is [Apache Spark](http://spark.apache.org), which is a general engine for
+large-scale data processing.
+
 
 # Usage
 
@@ -73,5 +103,5 @@ Just do (case sensitive)
 # Flags
 
 You can specifiy the colors for __good__ battery level, __middle__ battery level, and __warning__ battery level with the flags ``` -g -m -w ```.
-
 __Note:__ You should use color names for when in tmux mode and [ascii colors](http://www.termsys.demon.co.uk/vtansi.htm#colors) in terminal mode.
+In Mac OS, you can specify to use pmset with the `-p` flag; without it, the program uses `ioreg`. In linux, this flag is ignored, and always uses `upower`.

--- a/battery
+++ b/battery
@@ -70,13 +70,16 @@ fi
 
 
 run_battery() {
-if ((pmset_on)); then
-  BATTERY_STATUS="$(pmset -g batt | grep -o '[0-9]*%' | tr -d %)"
-else
-  BATTERY_STATUS="$(battery_charge)"
-fi
-
-[[ -z "$BATTERY_STATUS" ]] && exit 1
+    if [[ `uname -s` == 'Darwin' ]]; then
+        if ((pmset_on)); then
+            BATTERY_STATUS="$(pmset -g batt | grep -o '[0-9]*%' | tr -d %)"
+        else
+            BATTERY_STATUS="$(battery_charge)"
+        fi
+    elif [[ `uname -s` == 'Linux' ]]; then
+        BATTERY_STATUS="$(upower -i $(upower -e | grep BAT) | grep "percentage:" | grep -o '[0-9]*%' | tr -d '%')"
+    fi
+    [[ -z "$BATTERY_STATUS" ]] && exit 1
 }
 
 # Apply the correct color to the battery status prompt

--- a/battery
+++ b/battery
@@ -61,7 +61,11 @@ battery_charge() {
 }
 
 battery_external_connected() {
-  battery_info | grep "ExternalConnected" | cut -f2 -d' '
+    if [[ `uname -s` == 'Darwin' ]]; then
+        battery_info | grep "ExternalConnected" | cut -f2 -d' '
+    elif [[ `uname -s` == 'Linux' ]]; then
+        upower -i $(upower -e | grep BAT) | grep "state:" | grep -o 'discharging\|charging' | (read string; if [ $string == 'charging' ]; then echo "Yes"; else echo "No"; fi)
+    fi
 }
 
 if [[ ! $(battery_external_connected) = "No" ]]; then

--- a/battery
+++ b/battery
@@ -36,54 +36,69 @@ setDefaults() {
 
 setDefaults
 
-battery_info() {
-    ioreg -n AppleSmartBattery -r | \
-    grep -o '"[^"]*" = [^ ]*' | \
-    sed -e 's/= //g' -e 's/"//g' | \
-    sort
-}
+#battery_info() {
+#    ioreg -n AppleSmartBattery -r | \
+#    grep -o '"[^"]*" = [^ ]*' | \
+#    sed -e 's/= //g' -e 's/"//g' | \
+#    sort
+#}
 
 battery_charge() {
-    battery_info | \
-    while read key value; do
-        case $key in
-            "MaxCapacity")
-                export maxcap=$value;;
-            "CurrentCapacity")
-                export curcap=$value;;
-        esac
-        if [[ -n "$maxcap" && -n $curcap ]]; then
-            CAPACITY=$(( 100 * curcap / maxcap))
-            printf "%d" $CAPACITY
-            break
-        fi
-    done
+    case $(uname -s) in
+        "Darwin")
+            ioreg -n AppleSmartBattery -r | \
+            grep -o '"[^"]*" = [^ ]*' | \
+            sed -e 's/= //g' -e 's/"//g' | \
+            sort | \
+
+            while read key value; do
+                case $key in
+                    "MaxCapacity")
+                        export maxcap=$value;;
+                    "CurrentCapacity")
+                        export curcap=$value;;
+                    "ExternalConnected")
+                        if [ $value == "No" ]; then
+                            export connected=1
+                        else
+                            export connected=0
+                        fi
+                        ;;
+                esac
+                if [[ -n "$maxcap" && -n $curcap ]]; then
+                    CAPACITY=$(( 100 * curcap / maxcap))
+                    printf "%d" $CAPACITY
+                    break
+                fi
+            done
+            ;;
+        "Linux")
+            upower -i $(upower -e | grep BAT) | \
+            grep "state:" | grep -o 'discharging\|charging' | \
+            (read string; if [ $string == 'charging' ]; then export connected=0; else export connected=1; fi)
+            printf "%d" $(upower -i $(upower -e | grep BAT) | grep "percentage:" | grep -o '[0-9]*%' | tr -d '%')
+
+            ;;
+    esac
 }
 
-battery_external_connected() {
-    if [[ `uname -s` == 'Darwin' ]]; then
-        battery_info | grep "ExternalConnected" | cut -f2 -d' '
-    elif [[ `uname -s` == 'Linux' ]]; then
-        upower -i $(upower -e | grep BAT) | grep "state:" | grep -o 'discharging\|charging' | (read string; if [ $string == 'charging' ]; then echo "Yes"; else echo "No"; fi)
-    fi
-}
+#battery_external_connected() {
+#  battery_info | grep "ExternalConnected" | cut -f2 -d' '
+#}
 
-if [[ ! $(battery_external_connected) = "No" ]]; then
-  connected=1
-fi
+#if [[ ! $(battery_external_connected) = "No" ]]; then
+#  connected=1
+#fi
 
 
 run_battery() {
-    if [[ `uname -s` == 'Darwin' ]]; then
-        if ((pmset_on)); then
-            BATTERY_STATUS="$(pmset -g batt | grep -o '[0-9]*%' | tr -d %)"
-        else
-            BATTERY_STATUS="$(battery_charge)"
-        fi
-    elif [[ `uname -s` == 'Linux' ]]; then
-        BATTERY_STATUS="$(upower -i $(upower -e | grep BAT) | grep "percentage:" | grep -o '[0-9]*%' | tr -d '%')"
-    fi
-    [[ -z "$BATTERY_STATUS" ]] && exit 1
+    if ((pmset_on)) && hash pmset 2>/dev/null; then
+  BATTERY_STATUS="$(pmset -g batt | grep -o '[0-9]*%' | tr -d %)"
+else
+  BATTERY_STATUS="$(battery_charge)"
+fi
+
+[[ -z "$BATTERY_STATUS" ]] && exit 1
 }
 
 # Apply the correct color to the battery status prompt

--- a/battery
+++ b/battery
@@ -113,7 +113,11 @@ print_status() {
     if ((BATT_CONNECTED)); then
         GRAPH="⚡"
     else
-        GRAPH=$(spark 0 ${BATT_PCT} 100 | awk '{print substr($0,4,3)}')
+        if hash spark 2>/dev/null; then
+            GRAPH=$(spark 0 ${BATT_PCT} 100 | awk '{print substr($0,4,3)}')
+        else
+            ascii=1
+        fi
     fi
 
     if ((ascii)); then


### PR DESCRIPTION
There were a couple of things here:

* Added switch/case for different OSes based on `$(uname -s)`
* Added a case for Linux
* Removed `battery_info()` and `battery_external_connected` functions, moved their functionality into `battery_charge()`
* checked whether `pmset` was present on the computer