### PR TITLE
Add Linux support via /sys/class/power_supply/

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,6 @@ large-scale data processing.
 
 # Flags
 
-You can specifiy the colors for __good__ battery level, __middle__ battery level, and __warning__ battery level with the flags ``` -g -m -w ```.
+The flag `-b` will set a different battery path, the default value is `/sys/class/power_supply/BAT0`. You can specifiy the colors for __good__ battery level, __middle__ battery level, and __warning__ battery level with the flags ``` -g -m -w ```.
 __Note:__ You should use color names for when in tmux mode and [ascii colors](http://www.termsys.demon.co.uk/vtansi.htm#colors) in terminal mode.
 In Mac OS, you can specify to use pmset with the `-p` flag; without it, the program uses `ioreg`. In linux, this flag is ignored, and always uses `upower`.

--- a/battery
+++ b/battery
@@ -149,7 +149,7 @@ fi
 }
 
 # Read args
-while getopts ":g:m:w:tab:" opt; do
+while getopts ":g:m:w:tab:p" opt; do
   case $opt in
     g)
       good_color=$OPTARG

--- a/battery
+++ b/battery
@@ -173,7 +173,15 @@ while getopts ":g:m:w:tab:" opt; do
       pmset_on=1
       ;;
     b)
-      battery_path=$OPTARG
+	  if [ -d $OPTARG ]; then
+		battery_path=$OPTARG
+	  else
+		echo "Battery not found, trying to use default path..."
+	    if [ ! -d $battery_path ]; then
+		  echo "Default battery path is also unreachable"
+		  exit 1
+		fi
+	  fi
       ;;
     \?)
       echo "Invalid option: -$OPTARG"

--- a/battery
+++ b/battery
@@ -9,7 +9,7 @@ battery: usage:
     -p            use pmset (more accurate)
     -t            output tmux status bar format
     -a            output ascii bar instead of spark's
-
+    -b            battery path            default: /sys/class/power_supply/BAT0
   colors:
     -g <color>    good battery level      default: green or 1;32
     -m <color>    middle battery level    default: yellow or 1;33
@@ -32,6 +32,7 @@ setDefaults() {
   middle_color="1;33"
   warn_color="0;31"
   connected=0
+  battery_path=/sys/class/power_supply/BAT0
 }
 
 setDefaults
@@ -68,7 +69,6 @@ battery_charge() {
             fi
             ;;
         "Linux")
-			battery_path=/sys/class/power_supply/BAT0
 			battery_state=$(cat $battery_path/status)
 			battery_full=$battery_path/charge_full
 			battery_current=$battery_path/charge_now
@@ -148,7 +148,7 @@ fi
 }
 
 # Read args
-while getopts ":g:m:w:tap" opt; do
+while getopts ":g:m:w:tap:b:" opt; do
   case $opt in
     g)
       good_color=$OPTARG
@@ -170,6 +170,9 @@ while getopts ":g:m:w:tap" opt; do
       ;;
     p)
       pmset_on=1
+      ;;
+    b)
+      battery_path=$OPTARG
       ;;
     \?)
       echo "Invalid option: -$OPTARG"

--- a/battery
+++ b/battery
@@ -119,7 +119,8 @@ print_status() {
         GRAPH="⚡"
     else
         if hash spark 2>/dev/null; then
-            GRAPH=$(spark 0 ${BATT_PCT} 100 | awk '{print substr($0,4,3)}')
+			sparks=$(spark 0 ${BATT_PCT} 100)
+			GRAPH=${sparks:1:1}
         else
             ascii=1
         fi

--- a/battery
+++ b/battery
@@ -176,9 +176,9 @@ while getopts ":g:m:w:tab:p" opt; do
 	  if [ -d $OPTARG ]; then
 		battery_path=$OPTARG
 	  else
-		echo "Battery not found, trying to use default path..."
+		>&2 echo "Battery not found, trying to use default path..."
 	    if [ ! -d $battery_path ]; then
-		  echo "Default battery path is also unreachable"
+		  >&2 echo "Default battery path is also unreachable"
 		  exit 1
 		fi
 	  fi

--- a/battery
+++ b/battery
@@ -149,7 +149,7 @@ fi
 }
 
 # Read args
-while getopts ":g:m:w:tap:b:" opt; do
+while getopts ":g:m:w:tab:" opt; do
   case $opt in
     g)
       good_color=$OPTARG

--- a/battery
+++ b/battery
@@ -68,13 +68,18 @@ battery_charge() {
             fi
             ;;
         "Linux")
-            state=$(upower -i $(upower -e | grep BAT) | grep "state:" | grep -o 'discharging\|charging\|fully-charged')
-            if [ $state == 'discharging' ]; then
+			battery_path=/sys/class/power_supply/BAT0
+			battery_state=$(cat $battery_path/status)
+			battery_full=$battery_path/charge_full
+			battery_current=$battery_path/charge_now
+            if [ $battery_state == 'Discharging' ]; then
                 BATT_CONNECTED=0
             else
                 BATT_CONNECTED=1
             fi
-            BATT_PCT=$(upower -i $(upower -e | grep BAT) | grep "percentage" | grep -o '[0-9]*%' | tr -d '%')
+			now=$(cat $battery_current)
+			full=$(cat $battery_full)
+			BATT_PCT=$((100 * $now / $full))
             ;;
     esac
 }


### PR DESCRIPTION
The application 'upower' is not installed by default on all Linux
distros.

Making use of /sys/class/power_supply is a better option

It won't work on BSD