### PR TITLE
Add Linux distribution - Elementary OS

### DIFF
--- a/battery
+++ b/battery
@@ -75,7 +75,7 @@ battery_charge() {
             fi
             ;;
         "Linux")
-            case $(cat /etc/*-release) in
+            case $(grep . /etc/*-release -d skip) in
                 *"Arch Linux"*|*"Ubuntu"*|*"openSUSE"*)
                     battery_state=$(cat $battery_path/energy_now)
                     battery_full=$battery_path/energy_full

--- a/battery
+++ b/battery
@@ -81,6 +81,11 @@ battery_charge() {
                     battery_full=$battery_path/energy_full
                     battery_current=$battery_path/energy_now
                     ;;
+                *"elementary"*)
+                    battery_state=$(cat $battery_path/status)
+                    battery_full=$battery_path/energy_full
+                    battery_current=$battery_path/energy_now
+                    ;;
                 *)
                     battery_state=$(cat $battery_path/status)
                     battery_full=$battery_path/charge_full


### PR DESCRIPTION
Some linux distribution like elementary os has directory named `upstream-release`.
In this case cat execution encountered error with upstream-release is directory.
So I replaced cat to grep for exclude check directories.